### PR TITLE
Restore bullet styling for lists

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,7 +8,10 @@ body {
 }
 a { color: #90caf9; }
 img { max-width: 100%; height: auto; }
-ul { list-style: none; padding: 0; }
+ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
 li { margin-bottom: 0.5em; }
 
 .post-nav {


### PR DESCRIPTION
## Summary
- show bullet points again for unordered lists by restoring `list-style: disc` and left padding

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68983de8df20832dacfb99919ee6715d